### PR TITLE
Don't write to unchanged `package.json` files

### DIFF
--- a/__tests__/bin.js
+++ b/__tests__/bin.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const { execFile } = require("child_process");
-const { copyFileSync } = require("fs");
+const { copyFileSync, readFileSync, statSync } = require("fs");
 const { join } = require("path");
 
 const tmp = require("tmp");
@@ -11,7 +11,7 @@ const BIN = join(ROOT, "bin.js");
 const FIXTURES = join(__dirname, "fixtures");
 
 function exec(options = {}, args = []) {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     execFile("node", [BIN, ...args], options, (err, stdout, stderr) => {
       resolve({ err, stdout, stderr });
     });
@@ -41,6 +41,35 @@ describe("$ nice-package-json", () => {
     expect(stdout).toBe("");
     expect(stderr).toMatchSnapshot();
   });
+
+  describe(" --write", () => {
+    it("overwrites an existing package.json if changes are made", async () => {
+      const dir = tmp.dirSync();
+      const inputFile = join(FIXTURES, "input/full.json");
+      const expectedFile = join(FIXTURES, "expected/full.json");
+      const targetPkg = join(dir.name, "package.json");
+
+      copyFileSync(inputFile, targetPkg);
+
+      expect(readFileSync(targetPkg)).toEqual(readFileSync(inputFile));
+      await exec({ cwd: dir.name }, ["--write"]);
+      expect(readFileSync(targetPkg)).toEqual(readFileSync(expectedFile));
+    });
+
+    it("doesn't touch an existing package.json if no changes are made", async () => {
+      const dir = tmp.dirSync();
+      const inputFile = join(FIXTURES, "expected/full.json");
+      const targetPkg = join(dir.name, "package.json");
+
+      copyFileSync(inputFile, targetPkg);
+
+      const beforeModifiedTime = statSync(targetPkg).mtimeMs;
+      await exec({ cwd: dir.name }, ["--write"]);
+      const afterModifiedTime = statSync(targetPkg).mtimeMs;
+
+      expect(beforeModifiedTime).toBe(afterModifiedTime);
+    });
+  });
 });
 
 describe("$ nice-package-json /path/to/dir", () => {
@@ -51,9 +80,7 @@ describe("$ nice-package-json /path/to/dir", () => {
       join(FIXTURES, "input/full.json"),
       join(dir.name, "package.json")
     );
-    const { err, stdout, stderr } = await exec({ cwd: __dirname }, [
-      dir.name
-    ]);
+    const { err, stdout, stderr } = await exec({ cwd: __dirname }, [dir.name]);
     expect(err).toBeNull();
     expect(stdout).toMatchSnapshot();
     expect(stderr).toBe("");
@@ -61,7 +88,7 @@ describe("$ nice-package-json /path/to/dir", () => {
 
   it("shows an error when no package.json file is found", async () => {
     const { err, stdout, stderr } = await exec({ cwd: __dirname }, [
-      "/missing/dir"
+      "/missing/dir",
     ]);
     expect(err.message).toMatch("no package.json file found");
     expect(stdout).toMatchSnapshot();
@@ -78,7 +105,7 @@ describe("$ nice-package-json /path/to/package.json", () => {
       join(dir.name, "package.json")
     );
     const { err, stdout, stderr } = await exec({ cwd: dir.name }, [
-      "./package.json"
+      "./package.json",
     ]);
     expect(err).toBeNull();
     expect(stdout).toMatchSnapshot();
@@ -87,7 +114,7 @@ describe("$ nice-package-json /path/to/package.json", () => {
 
   it("shows an error if the file is not valid JSON", async () => {
     const { err, stdout, stderr } = await exec({ cwd: __dirname }, [
-      "/missing/dir/package.json"
+      "/missing/dir/package.json",
     ]);
     expect(err.message).toMatch("no package.json file found");
     expect(stdout).toMatchSnapshot();

--- a/bin.js
+++ b/bin.js
@@ -10,7 +10,7 @@ const meow = require("meow");
 const nicePackageJson = require("./");
 
 const FLAGS = {
-  write: { type: "boolean" }
+  write: { type: "boolean" },
 };
 
 const KNOWN_FLAG_NAMES = Object.keys(FLAGS);
@@ -34,7 +34,7 @@ function main() {
     { flags: FLAGS }
   );
 
-  Object.keys(cli.flags).forEach(flag => {
+  Object.keys(cli.flags).forEach((flag) => {
     if (KNOWN_FLAG_NAMES.includes(flag) === false) {
       err(`invalid argument "${flag}"`);
       process.exit(1);
@@ -59,12 +59,14 @@ function main() {
 
   try {
     const pkgData = readFileSync(pkgPath);
-    const pkg = JSON.parse(pkgData);
-    const formatted = nicePackageJson(pkg);
+    const inputPkg = JSON.parse(pkgData);
+    const formattedPkg = nicePackageJson(inputPkg);
     if (cli.flags.write === true) {
-      writeFileSync(pkgPath, formatted);
+      if (pkgData.toString() !== formattedPkg) {
+        writeFileSync(pkgPath, formattedPkg);
+      }
     } else {
-      process.stdout.write(formatted);
+      process.stdout.write(formattedPkg);
     }
   } catch (e) {
     console.error("Unknown Error:", e);

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,7 +2,7 @@
  * An opinionated formatter for package.json files
  *
  * @param object - parsed package.json contents
- * @returns A formatted package.json structure
+ * @returns {string} A formatted package.json structure
  */
 declare function nicePackageJson<T extends object>(object: T): T;
 


### PR DESCRIPTION
Currently the `package.json` file is written to regardless of whether or not any formatting changes occurred. This can cause unnecessary churn in other tools that might be watching that file for changes.

Closes #3